### PR TITLE
smater install - for darwin with preinsttled libraries just remove *gfor...

### DIFF
--- a/load-blapack-libs.lisp
+++ b/load-blapack-libs.lisp
@@ -7,40 +7,31 @@
 
 (in-package :org.middleangle.load-blapack-libs)
 
-;; EDIT THESE VARIABLES TO POINT TO YOUR LIBRARIES!
 
 
-#|
-;;; The suggestion (from Leo (sdl.web at gmail dot com) to use native
-;;; accelerated BLAS and LAPACK on MacOSX is to COMMENT OUT the
-;;; gfortran lib DEFPARAMETER and LOAD-FOREIGN-LIBRARY, as it is not
-;;; linked in, and to use the following locations:
 
-  ;; (defparameter *gfortran-lib* "/usr/lib/libgfortran.so.3")
-  (defparameter *blas-lib*
-     "/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib")
-  (defparameter *lapack-lib*
-     "/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/Versions/A/libLAPACK.dylib")
-
-;;; and then for the load, comment it out:
-
-+      ;; (load-foreign-library *gfortran-lib*)
-
-;;; This might not hold for your MacOSX setup, please report back!
-|#
 
 
 (eval-when (:compile-toplevel :load-toplevel)
+#+darwin 
+  (progn
+    (defparameter *gfortran-lib* nil)
+    (defparameter *blas-lib*
+      "/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib")
+    (defparameter *lapack-lib*
+      "/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/Versions/A/libLAPACK.dylib"))
+#-darwin
+  (progn
+    (defparameter *gfortran-lib* "libgfortran.so.3")
+    (defparameter *blas-lib* "libblas.so")
+    (defparameter *lapack-lib* "liblapack.so"))
 
-  (defparameter *gfortran-lib* "/usr/lib/libgfortran.so.3")
-  (defparameter *blas-lib* "/usr/lib/libblas.so")
-  (defparameter *lapack-lib* "/usr/lib/liblapack.so")
-
+  
   (defvar *blapack-libs-loaded* nil)
 
   (unless *blapack-libs-loaded*
     (progn
-      (load-foreign-library *gfortran-lib*)
+      (when *gfortran-lib* (load-foreign-library *gfortran-lib*))
       (load-foreign-library *blas-lib*)
       (load-foreign-library *lapack-lib*)
       (setf *blapack-libs-loaded* t))))


### PR DESCRIPTION
...tranlib\* otherwise assume the neccessary fortran, BLAS & LAPACK libs are in the LOAD_LIBRARY_PATH for linux.
