### PR TITLE
Make it build with ASDF 3.3

### DIFF
--- a/generate-blapack-interface.lisp
+++ b/generate-blapack-interface.lisp
@@ -182,24 +182,17 @@ remaining lines."
 ;; Edit these if you want to change the input/output locations!
 (defparameter *basedir* #p"/home/rif/software/LAPACK/")
 (defparameter *outdir*
-  (make-pathname :directory
-                 (pathname-directory
-                  (truename (asdf:system-definition-pathname
-                             (asdf:find-system
-                              :org.middleangle.cl-blapack-gen))))))
+  (asdf:system-source-directory "org.middleangle.cl-blapack-gen"))
+
+(defun fortran-dir-parsing-helper (basedir wildcard)
+  (mapcar
+   (lambda (f) (multiple-value-bind (name vars ret) (parse-fortran-file f)
+                 (list name vars ret)))
+   (uiop:directory-files basedir wildcard)))
 
 (defmacro fortran-dir-parsing-fn (fn-name fortran-files-wildcard-string)
-  `(defun ,fn-name  (&optional (basedir *basedir*))
-     (let ((files
-	    (directory
-	     (pathname 
-	      (concatenate 'string (namestring basedir)
-			   ,fortran-files-wildcard-string)))))
-       (mapcar (lambda (f)
-		 (multiple-value-bind (name vars ret)
-		     (parse-fortran-file f)
-		   (list name vars ret)))
-	       files))))
+  `(defun ,fn-name (&optional (basedir *basedir*))
+     (fortran-dir-parsing-helper basedir ,fortran-files-wildcard-string)))
 
 ;; above macro WHEN PROPERLY written (still need to verify the above)
 ;; should simplify the following two functions into something like:
@@ -207,7 +200,7 @@ remaining lines."
 ;; (defvar *basedir* "testme/")
 ;; (fortran-dir-parsing-fn my-parse-blas-files "BLAS/SRC/*.f") ; slime: C-c M-m
 ;; (fortran-dir-parsing-fn my-parse-lapack-files "SRC/*.f")    ; slime: C-c M-m
-;; 
+;;
 ;; The reason is that we'd like to add in other Fortran libraries if
 ;; possible, and factor out the auto-gen bindings into a
 ;; cffi-fortran-grovel package.

--- a/org.middleangle.cl-blapack-examples.asd
+++ b/org.middleangle.cl-blapack-examples.asd
@@ -3,7 +3,7 @@
 ;; Copyright rif 2006.
 ;; Modified BSD License (see LICENSE file in this directory).
 
-(defsystem :org.middleangle.cl-blapack-examples
-  :depends-on (:org.middleangle.cl-blapack)
+(defsystem "org.middleangle.cl-blapack-examples"
+  :depends-on ("org.middleangle.cl-blapack")
   :components
   ((:file "examples")))

--- a/org.middleangle.cl-blapack-gen.asd
+++ b/org.middleangle.cl-blapack-gen.asd
@@ -3,8 +3,8 @@
 ;; Copyright rif 2006.
 ;; Modified BSD License (see LICENSE file in this directory).
 
-(defsystem :org.middleangle.cl-blapack-gen
-    :depends-on (:cffi :org.middleangle.foreign-numeric-vector)
+(defsystem "org.middleangle.cl-blapack-gen"
+    :depends-on ("cffi" "org.middleangle.foreign-numeric-vector")
     :components
     ((:file "blapack-cffi-types")
      (:file "generate-blapack-interface" :depends-on ("blapack-cffi-types"))))

--- a/org.middleangle.cl-blapack.asd
+++ b/org.middleangle.cl-blapack.asd
@@ -1,29 +1,21 @@
 ;;;; -*- Mode: LISP; Syntax: ANSI-Common-Lisp; Base: 10 -*-
 
-(in-package :cl-user)
-(defpackage :org.middleangle.cl-blapack-asd
-  (:nicknames :cl-blapack-asd)
-  (:use :cl :asdf))
-
-(in-package :org.middleangle.cl-blapack-asd)
-
 ;; Copyright rif 2006.
 ;; Modified BSD License (see LICENSE file in this directory).
 
-(defsystem :org.middleangle.cl-blapack
-  :depends-on (:cffi :org.middleangle.foreign-numeric-vector)
+(defsystem "org.middleangle.cl-blapack"
+  :depends-on ("cffi" "org.middleangle.foreign-numeric-vector")
   :components
   ((:file "packages")
    (:file "features" :depends-on ("packages"))
    (:file "bugfix" :depends-on ("packages" "features"))
    (:file "load-blapack-libs" :depends-on ("packages" "bugfix"))
-
    (:file "blapack-cffi-types" :depends-on ("packages" "bugfix"))
-   (:file "blas-cffi" :depends-on ( "load-blapack-libs"
+   (:file "blas-cffi" :depends-on ("load-blapack-libs"
 				   "blapack-cffi-types"
                                    "bugfix"))
    (:file "lapack-cffi" :depends-on ("load-blapack-libs"
 				     "blapack-cffi-types"
                                      "bugfix"))
-   (:file "cl-blapack" :depends-on ("packages"   "bugfix"
+   (:file "cl-blapack" :depends-on ("packages" "bugfix"
 				    "blas-cffi" "lapack-cffi"))))


### PR DESCRIPTION
Stop using system-definition-pathname, use system-source-directory.

Also, use uiop:directory-files as appropriate.

Finally, cleanup the .asd files according to recommendations.